### PR TITLE
Support container create, start and stop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "docker-sync"
 description = "Minimalistic, synchronous, read-only client for local Docker socket"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Benoit Petit <bpetit@hubblo.org>"]
 license = "Apache-2.0"
 homepage = "https://github.com/bpetit/rs-docker-sync"

--- a/src/container.rs
+++ b/src/container.rs
@@ -167,6 +167,8 @@ pub struct HostConfigCreate {
     pub NetworkMode: Option<String>,
     pub PublishAllPorts: Option<bool>,
     pub PortBindings: Option<HashMap<String, Vec<PortBinding>>>,
+    pub AutoRemove: Option<bool>,
+    pub Binds: Option<Vec<String>>,
 }
 
 impl Clone for HostConfigCreate {
@@ -175,6 +177,8 @@ impl Clone for HostConfigCreate {
             NetworkMode: self.NetworkMode.clone(),
             PublishAllPorts: self.PublishAllPorts,
             PortBindings: self.PortBindings.clone(),
+            AutoRemove: self.AutoRemove.clone(),
+            Binds: self.Binds.clone(),
         }
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -192,18 +192,60 @@ impl std::fmt::Display for HostConfigCreate {
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(non_snake_case)]
 pub struct ContainerCreate {
+    pub Hostname: Option<String>,
+    pub Domainname: Option<String>,
+    pub User: Option<String>,
+    pub AttachStdin: Option<bool>,
+    pub AttachStdout: Option<bool>,
+    pub AttachStderr: Option<bool>,
+    pub ExposedPorts: Option<HashMap<String, EmptyObject>>,
+    pub Tty: Option<bool>,
+    pub OpenStdin: Option<bool>,
+    pub StdinOnce: Option<bool>,
+    pub Env: Option<Vec<String>>,
+    pub Cmd: Option<Vec<String>>,
+    pub ArgsEscaped: Option<bool>,
     pub Image: String,
+    pub Volumes: Option<HashMap<String, EmptyObject>>,
+    pub WorkingDir: Option<String>,
+    pub Entrypoint: Option<Vec<String>>,
+    pub NetworkDisabled: Option<bool>,
+    pub MacAddress: Option<String>,
+    pub OnBuild: Option<Vec<String>>,
     pub Labels: Option<HashMap<String, String>>,
-    pub ExposedPorts: Option<HashMap<String, HashMap<i32, i32>>>,
+    pub StopSignal: Option<String>,
+    pub StopTimeout: Option<u64>,
+    pub Shell: Option<Vec<String>>,
     pub HostConfig: Option<HostConfigCreate>,
 }
 
 impl Clone for ContainerCreate {
     fn clone(&self) -> Self {
         ContainerCreate {
-            Image: self.Image.clone(),
-            Labels: self.Labels.clone(),
+            Hostname: self.Hostname.clone(),
+            Domainname: self.Domainname.clone(),
+            User: self.User.clone(),
+            AttachStdin: self.AttachStdin,
+            AttachStdout: self.AttachStdout,
+            AttachStderr: self.AttachStderr,
             ExposedPorts: self.ExposedPorts.clone(),
+            Tty: self.Tty,
+            OpenStdin: self.OpenStdin,
+            StdinOnce: self.StdinOnce,
+            Env: self.Env.clone(),
+            Cmd: self.Cmd.clone(),
+            ArgsEscaped: self.ArgsEscaped,
+            Image: self.Image.clone(),
+            Volumes: self.Volumes.clone(),
+            WorkingDir: self.WorkingDir.clone(),
+            Entrypoint: self.Entrypoint.clone(),
+            NetworkDisabled: self.NetworkDisabled,
+            MacAddress: self.MacAddress.clone(),
+            OnBuild: self.OnBuild.clone(),
+            Labels: self.Labels.clone(),
+            StopSignal: self.StopSignal.clone(),
+            StopTimeout: self.StopTimeout,
+            Shell: self.Shell.clone(),
             HostConfig: self.HostConfig.clone(),
         }
     }
@@ -214,3 +256,39 @@ impl std::fmt::Display for ContainerCreate {
         write!(f, "{}", self.Image)
     }
 }
+
+impl Default for ContainerCreate {
+    fn default() -> Self {
+        ContainerCreate {
+            Hostname: None,
+            Domainname: None,
+            User: None,
+            AttachStdin: None,
+            AttachStdout: None,
+            AttachStderr: None,
+            ExposedPorts: None,
+            Tty: None,
+            OpenStdin: None,
+            StdinOnce: None,
+            Env: None,
+            Cmd: None,
+            ArgsEscaped: None,
+            Image: String::new(),
+            Volumes: None,
+            WorkingDir: None,
+            Entrypoint: None,
+            NetworkDisabled: None,
+            MacAddress: None,
+            OnBuild: None,
+            Labels: None,
+            StopSignal: None,
+            StopTimeout: None,
+            Shell: None,
+            HostConfig: None,
+        }
+    }
+}
+
+/// A struct representing the value `{}` in JSON.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct EmptyObject {}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -9,7 +9,7 @@ use crate::system::SystemInfo;
 use crate::version::Version;
 use http::method::Method;
 use isahc::{config::Dialer, prelude::*, send, Body, Request};
-use std::io::{Read, Error, ErrorKind};
+use std::io::{Error, ErrorKind, Read};
 use std::path::Path;
 
 pub struct Docker {
@@ -21,7 +21,10 @@ impl Docker {
         let path = String::from("/var/run/docker.sock");
         let file = Path::new(&path);
         if !file.exists() {
-            return Err(Error::new(ErrorKind::NotFound, format!("{} not found.", path)))
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("{} not found.", path),
+            ));
         }
         let dialer = Dialer::unix_socket(path);
         Ok(Docker { dialer })
@@ -48,10 +51,7 @@ impl Docker {
                 reason.push_str("Server error:");
             }
             reason.push_str(res.status().canonical_reason().unwrap());
-            return Err(Error::new(
-                ErrorKind::Other,
-                reason
-            ));
+            return Err(Error::new(ErrorKind::Other, reason));
         }
 
         let body = res.body_mut();


### PR DESCRIPTION
Hi! These are a few changes I've needed and thought you might appreciate them sent upstream.

There are a few separate things here, shout if you'd prefer them split into multiple PRs:

1. An existing commit that releases version 0.1.2, which I believe should be on `master` but isn't for some reason.
2. Add `AutoRemove` and `Binds` to `HostConfigCreate`. There are more fields we could add here but these are just the ones I needed for my use case.
3. Flesh out the `ContainerCreate` type, adding all fields in the Docker API reference. I've also added a `Default` impl so you don't need to write out two dozen `None` fields explicitly.
4. Finally, add the methods `create_container`, `start_container` and `stop_container` for managing containers.

The existing tests appear to be purely to test deserialisation. None of these methods return complex objects so I've not added any tests.